### PR TITLE
fix ROS2 compile error

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "com.frj.unity-sensors": "https://github.com/Field-Robotics-Japan/UnitySensors.git?path=/Assets/UnitySensors#v2.0.4",
-    "com.frj.unity-sensors-ros": "https://github.com/Field-Robotics-Japan/UnitySensors.git?path=/Assets/UnitySensorsROS#v2.0.4",
+    "com.frj.unity-sensors": "https://github.com/Field-Robotics-Japan/UnitySensors.git?path=/Assets/UnitySensors#master",
+    "com.frj.unity-sensors-ros": "https://github.com/Field-Robotics-Japan/UnitySensors.git?path=/Assets/UnitySensorsROS#master",
     "com.unity.ai.navigation": "1.1.5",
     "com.unity.burst": "1.8.12",
     "com.unity.collab-proxy": "2.0.7",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -8,23 +8,23 @@
       "url": "https://packages.unity.com"
     },
     "com.frj.unity-sensors": {
-      "version": "https://github.com/Field-Robotics-Japan/UnitySensors.git?path=/Assets/UnitySensors#v2.0.4",
+      "version": "https://github.com/Field-Robotics-Japan/UnitySensors.git?path=/Assets/UnitySensors#master",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.burst": "1.6.6"
       },
-      "hash": "c33247ddf20b836cfd6db0099c54ee733f109625"
+      "hash": "b1a50503bb38017f902cb232b489de2de334d62b"
     },
     "com.frj.unity-sensors-ros": {
-      "version": "https://github.com/Field-Robotics-Japan/UnitySensors.git?path=/Assets/UnitySensorsROS#v2.0.4",
+      "version": "https://github.com/Field-Robotics-Japan/UnitySensors.git?path=/Assets/UnitySensorsROS#master",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.frj.unity-sensors": "2.0.4",
         "com.unity.robotics.ros-tcp-connector": "0.7.0-preview"
       },
-      "hash": "c33247ddf20b836cfd6db0099c54ee733f109625"
+      "hash": "b1a50503bb38017f902cb232b489de2de334d62b"
     },
     "com.unity.ai.navigation": {
       "version": "1.1.5",


### PR DESCRIPTION
UnitySensors 2.0.4に存在するROS2コンパイルエラーの問題に対する対処です。