### PR TITLE
Joint Pos ControllerのInitTargetPosが有効となっていなかった点を修正

### DIFF
--- a/Assets/Scripts/JointPosController.cs
+++ b/Assets/Scripts/JointPosController.cs
@@ -14,20 +14,21 @@ public class JointPosController : MonoBehaviour
     [Tooltip("角度設定コマンドのROSトピック名")]
     public string setpointTopicName = "joint_name/setpoint";
 
-    [Tooltip("初期の目標角度")]
+    [Tooltip("初期の目標角度(degree)")]
     public double initTargetPos;
 
     private ArticulationBody joint;
     private Float64Msg targetPos;
 
     // Start is called before the first frame update
-    void Start()
+    IEnumerator Start()
     {
+        yield return new WaitForSeconds(0.1f); // 少し待機してから設定
         ros = ROSConnection.GetOrCreateInstance();
         joint = this.GetComponent<ArticulationBody>();
         targetPos = new Float64Msg();
 
-        if (joint)
+        if(joint)
         {
             var drive = joint.xDrive;
             if (drive.stiffness == 0)
@@ -36,6 +37,8 @@ public class JointPosController : MonoBehaviour
                 drive.damping = 100000;
             if (drive.forceLimit == 0)
                 drive.forceLimit = 100000;
+
+            drive.target = (float)initTargetPos;
             joint.xDrive = drive;
         }
         else
@@ -43,7 +46,6 @@ public class JointPosController : MonoBehaviour
             Debug.Log("No ArticulationBody are found");
         }
 
-        targetPos.data = initTargetPos;
         ros.Subscribe<Float64Msg>(setpointTopicName, ExecuteJointPosControl);
     }
 


### PR DESCRIPTION
Joint Pos ControllerのInit Target Posがいつの間にか無効になっていたものを修正しました
（Start関数実行時、最初に0.1秒waitを設けました）
またInit Target Posの単位が[degree]である旨、Tooltipに明記しました
本件、[#68のissue](https://github.com/pwri-opera/OperaSim-PhysX/issues/68)への対応になります