### PR TITLE
Feature/add rgb camera

### DIFF
--- a/Assets/Other 3rd Party Series/Resources/ROSConnectionPrefab.prefab
+++ b/Assets/Other 3rd Party Series/Resources/ROSConnectionPrefab.prefab
@@ -59,7 +59,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7acef0b79454c9b4dae3f8139bc4ba77, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_RosIPAddress: localhost
+  m_RosIPAddress: 172.19.2.71
   m_RosPort: 10000
   m_ConnectOnStart: 1
   m_KeepaliveTime: 1

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -620,7 +620,7 @@ PlayerSettings:
   webGLMemoryGeometricGrowthCap: 96
   webGLPowerPreference: 2
   scriptingDefineSymbols:
-    Standalone: 
+    Standalone: ROS2
   additionalCompilerArguments: {}
   platformArchitecture: {}
   scriptingBackend: {}


### PR DESCRIPTION
LiDARとRGB カメラをzx120のキャビン前方上部に取り付けてROS topic出力を確認しました
実機には搭載していないのでデフォルトではdisableにしています

@yosuke 
確認のうえ、問題なければマージいただけますでしょうか